### PR TITLE
Made input/output sections to cover entire screen real estate (height)

### DIFF
--- a/content-pkg/jcr_root/apps/repl/components/repl/clientlibs/style.css
+++ b/content-pkg/jcr_root/apps/repl/components/repl/clientlibs/style.css
@@ -1,8 +1,3 @@
-
-body {
-    margin: 0 10px;
-}
-
 h1 {
     margin-top: 10px;
 }
@@ -15,12 +10,17 @@ iframe {
     min-height: 100px;
     background: url('./images/sightly.svg') no-repeat 50% 100%;
 }
+
+#input {
+    height: calc(100vh - 100px);
+}
+
 #input .editor {
-    height: 300px;
+    height: calc(50vh - 100px);
 }
 
 #output .output-view {
-    height: 650px;
+    height: calc(100vh - 150px);
 }
 
 #output .nav {
@@ -31,7 +31,7 @@ iframe {
     #output .lead {
         display: none;
     }
-    
+
     #output .nav {
         margin: -8px 0 10px;
     }

--- a/content-pkg/jcr_root/apps/repl/components/repl/repl.html
+++ b/content-pkg/jcr_root/apps/repl/components/repl/repl.html
@@ -1,48 +1,56 @@
 <!DOCTYPE html>
 <html lang="en" data-sly-use.clientLib="${'/libs/granite/sightly/templates/clientlib.html'}">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-        <title>${currentPage.title || currentPage.name}</title>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-        <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
-        
-        <sly data-sly-call="${clientLib.css @ categories='repl'}" data-sly-unwrap></sly>
-    </head>
-    
-    <body data-sly-use.repl="repl.js">
-        <div id="logo" title="${properties.jcr:title}">&nbsp;</div>
+    <title>${currentPage.title || currentPage.name}</title>
 
-        <div id="main" class="row">
-            <div id="input" class="col-xs-6">
-                <div class="editorContainer">
-                    <p class="lead">${repl.templateFile}</p>
-                    <div id="template" class="editor" data-src="${repl.templatePath @ context='uri'}" data-mode="ace/mode/html" data-writeable></div>
-                </div>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css">
 
-                <div class="editorContainer">
-                    <p class="lead">${repl.logicFile}</p>
-                    <div id="logic" class="editor" data-src="${repl.logicPath @ context='uri'}" data-mode="ace/mode/javascript" data-writeable></div>
-                </div>
+    <sly data-sly-call="${clientLib.css @ categories='repl'}" data-sly-unwrap></sly>
+</head>
+
+<body data-sly-use.repl="repl.js">
+<div id="logo" title="${properties.jcr:title}">&nbsp;</div>
+
+<div class="container-fluid">
+    <div id="main" class="row">
+        <div id="input" class="col-xs-6">
+            <div class="editorContainer">
+                <p class="lead">${repl.templateFile}</p>
+                <div id="template" class="editor" data-src="${repl.templatePath @ context='uri'}" data-mode="ace/mode/html" data-writeable></div>
             </div>
-            <div id="output" class="editorContainer col-xs-6">
-                <div class="clearfix">
-                    <p class="lead pull-left">output.html</p>
-                    <ul class="nav nav-pills navbar-right">
-                        <li class="active"><a data-toggle="tab" href="#source">Source</a></li>
-                        <li><a data-toggle="tab" href="#view">View</a></li>
-                    </ul>
-                </div>
-                <div id="source" class="output-view editor" data-src="${repl.contentPath @ context='uri'}?wcmmode=disabled" data-mode="ace/mode/html"></div>
-                <iframe id="view" class="output-view hidden" src="${repl.contentPath}?wcmmode=disabled"></iframe>
+
+            <div class="editorContainer">
+                <p class="lead">${repl.logicFile}</p>
+                <div id="logic" class="editor" data-src="${repl.logicPath @ context='uri'}" data-mode="ace/mode/javascript" data-writeable></div>
             </div>
         </div>
+        <div id="output" class="editorContainer col-xs-6">
+            <div class="clearfix">
+                <p class="lead pull-left">output.html</p>
+                <ul class="nav nav-pills navbar-right">
+                    <li class="active"><a data-toggle="tab" href="#source">Source</a></li>
+                    <li><a data-toggle="tab" href="#view">View</a></li>
+                    <li><a data-toggle="tab" href="#java">Java</a></li>
+                </ul>
+            </div>
+            <div id="source" class="output-view editor" data-src="${repl.contentPath @ context='uri'}?wcmmode=disabled" data-mode="ace/mode/html"></div>
+            <iframe id="view" class="output-view hidden" src="${repl.contentPath}?wcmmode=disabled"></iframe>
+            <div id="java" class="output-view editor hidden" data-src="${repl.classPath @ context='uri'}" data-mode="ace/mode/java"></div>
+        </div>
+    </div>
+</div>
 
-        <sly data-sly-call="${clientLib.js @ categories='repl'}" data-sly-unwrap></sly>
-        <script src="https://netdna.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js"></script>
-    </body>
+<sly data-sly-call="${clientLib.js @ categories='repl'}" data-sly-unwrap></sly>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js"></script>
+<!--[if lt IE 9]>
+<script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+<script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+<![endif]-->
+</body>
 </html>


### PR DESCRIPTION
Made input/output sections to cover entire screen real estate, this makes it better for when developing on larger monitors rather than restricting the user to the fixed height view.

Also updated to the latest Bootstrap CDN and wrapped row in .container-fluid for better spacing on body.